### PR TITLE
Integrate iOS Notes as Collection Data Source: Add URL Scheme Parameter Handling

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,6 +21,7 @@ import { useFonts } from "expo-font";
 import { SplashScreen, Stack } from "expo-router";
 import { StatusBar } from "expo-status-bar";
 import { useContext, useEffect } from "react";
+import * as Linking from "expo-linking";
 import {
   InteractionManager,
   Keyboard,
@@ -38,6 +39,7 @@ import useShareIntent from "../hooks/useShareIntent";
 import { config } from "../tamagui.config";
 import { DatabaseContext, DatabaseProvider } from "../utils/db";
 import { UserProvider } from "../utils/user";
+import { parseGatherUrlScheme } from "../utils/urlScheme";
 import { ErrorsProvider } from "../utils/errors";
 import { useMilestoneCheck } from "../utils/celebrations";
 
@@ -152,7 +154,7 @@ const ParentStackComponent = Platform.OS === "android" ? JsStack : Stack;
 
 function RootLayoutNav() {
   const { shareIntent, resetShareIntent } = useShareIntent();
-  const { setShareIntent } = useContext(DatabaseContext);
+  const { setShareIntent, setCaptureIntent } = useContext(DatabaseContext);
 
   useEffect(() => {
     if (shareIntent !== null) {
@@ -160,6 +162,28 @@ function RootLayoutNav() {
       resetShareIntent();
     }
   }, [shareIntent]);
+
+  useEffect(() => {
+    const handleUrl = ({ url }: { url: string }) => {
+      const params = parseGatherUrlScheme(url);
+      if (params) {
+        setCaptureIntent(params);
+      }
+    };
+
+    const subscription = Linking.addEventListener("url", handleUrl);
+
+    Linking.getInitialURL().then((url) => {
+      if (url) {
+        handleUrl({ url });
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [setCaptureIntent]);
+
   useMilestoneCheck();
 
   return (

--- a/utils/db.tsx
+++ b/utils/db.tsx
@@ -32,6 +32,7 @@ import {
 } from "react";
 import { useDebounce, useDebounceValue } from "tamagui";
 import { ShareIntent } from "../hooks/useShareIntent";
+import { GatherUrlSchemeParams } from "./urlScheme";
 import {
   ArenaChannelInfo,
   createBlock as createBlockArena,
@@ -42,6 +43,13 @@ import {
   removePendingBlockUpdate,
   updateArenaBlock,
 } from "./arena";
+
+export interface CaptureIntent {
+  text?: string;
+  collectionId?: string;
+  title?: string;
+  source?: string;
+}
 import {
   CollectionToReviewKey,
   getLastSyncedInfoForChannel,
@@ -227,6 +235,10 @@ interface DatabaseContextProps {
   setShareIntent: (intent: ShareIntent | null) => void;
   shareIntent: ShareIntent | null;
 
+  // capture intent
+  setCaptureIntent: (intent: CaptureIntent | null) => void;
+  captureIntent: CaptureIntent | null;
+
   // arena
   tryImportArenaChannel: (
     arenaChannel: string | ArenaChannelInfo,
@@ -288,6 +300,9 @@ export const DatabaseContext = createContext<DatabaseContextProps>({
 
   setShareIntent: () => {},
   shareIntent: null,
+
+  setCaptureIntent: () => {},
+  captureIntent: null,
 
   tryImportArenaChannel: async () => {
     throw new Error("not yet loaded");
@@ -2260,6 +2275,7 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
   }
 
   const [shareIntent, setShareIntent] = useState<ShareIntent | null>(null);
+  const [captureIntent, setCaptureIntent] = useState<CaptureIntent | null>(null);
 
   async function tryImportArenaChannel(
     arenaChannel: string | ArenaChannelInfo,
@@ -2351,6 +2367,8 @@ export function DatabaseProvider({ children }: PropsWithChildren<{}>) {
         deleteBlock,
         setShareIntent,
         shareIntent,
+        setCaptureIntent,
+        captureIntent,
         getConnectionsForBlock,
         createCollection,
         updateCollection,

--- a/utils/urlScheme.ts
+++ b/utils/urlScheme.ts
@@ -1,0 +1,60 @@
+export interface GatherUrlSchemeParams {
+  text?: string;
+  collectionId?: string;
+  title?: string;
+  source?: string;
+}
+
+function parseQueryString(queryString: string): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  if (!queryString) {
+    return params;
+  }
+
+  const pairs = queryString.split("&");
+  for (const pair of pairs) {
+    const [key, value] = pair.split("=");
+    if (key && value !== undefined) {
+      params[key] = decodeURIComponent(value.replace(/\+/g, " "));
+    }
+  }
+
+  return params;
+}
+
+export function parseGatherUrlScheme(url: string): GatherUrlSchemeParams | null {
+  try {
+    if (!url.startsWith("net.tiny-inter.gather://")) {
+      return null;
+    }
+
+    const queryStringMatch = url.match(/\?(.+)$/);
+    if (!queryStringMatch) {
+      return {};
+    }
+
+    const queryParams = parseQueryString(queryStringMatch[1]);
+    const params: GatherUrlSchemeParams = {};
+
+    if (queryParams.text) {
+      params.text = queryParams.text;
+    }
+
+    if (queryParams.collectionId) {
+      params.collectionId = queryParams.collectionId;
+    }
+
+    if (queryParams.title) {
+      params.title = queryParams.title;
+    }
+
+    if (queryParams.source) {
+      params.source = queryParams.source;
+    }
+
+    return params;
+  } catch (error) {
+    return null;
+  }
+}


### PR DESCRIPTION
This PR was created automatically by Aviator Runbooks.
**Runbook URL**: http://localhost:5000/r/111
**Executed by**: @simsinght

<details>
<summary>💡 Revise with Runbooks</summary>

Use `/aviator revise` to address the feedback provided on this PR:

**As a PR comment:**

- `/aviator revise` - Process all unresolved review comments on the PR
- `/aviator revise [instructions]` - Process any unresolved comments and handle additional instructions.

**As a review comment:**

- Reply with `/aviator revise [instructions]` to an existing review comment to address that specific thread
- Post `/aviator revise [instructions]` as a review comment to have Runbooks revise that code section based on given instructions.

[Read the complete guide with examples](https://docs.aviator.co/runbooks/how-to-guides/providing-feedback)

</details>

## Steps

**Included in this PR**
- 1.1 Add URL parameter parsing utility
- 1.2 Add URL scheme listener in root layout

<details>
<summary>View all Runbook steps (2 of 9 complete)</summary>

1. **Add URL Scheme Parameter Handling**
   - 1.1 Add URL parameter parsing utility 👈
   - 1.2 Add URL scheme listener in root layout 👈
   - 1.3 Extend DatabaseContext with capture intent state
2. **Create Quick Capture Screen**
   - 2.1 Create capture screen component
   - 2.2 Auto-populate capture screen from URL scheme
   - 2.3 Add quick access to capture screen
3. **Create iOS Shortcut for Text Capture**
   - 3.1 Create basic "Add to Gather" shortcut
   - 3.2 Add shortcut to Home Screen widget
   - 3.3 Optional: Add Siri voice trigger

</details>

<!-- av pr metadata
This comment helps Aviator manage stacked PRs. Please don't delete it.
```
{"parent": "main", "parentHead": null, "parentPull": null, "trunk": "main"}
```
-->