### PR TITLE
Integrate iOS Notes as Collection Data Source: Create Quick Capture Screen

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -275,6 +275,13 @@ function RootLayoutNav() {
         }}
       />
       <Stack.Screen
+        name="capture"
+        options={{
+          presentation: "card",
+          title: "Quick Capture",
+        }}
+      />
+      <Stack.Screen
         name="collection/[id]/index"
         options={{
           presentation: "card",

--- a/app/capture.tsx
+++ b/app/capture.tsx
@@ -1,0 +1,132 @@
+import { H3, Spinner, XStack, YStack } from "tamagui";
+import {
+  StyledButton,
+  StyledText,
+  StyledTextArea,
+  StyledView,
+  Icon,
+} from "../components/Themed";
+import { CollectionSelect } from "../components/CollectionSelect";
+import { useContext, useState } from "react";
+import { UserContext } from "../utils/user";
+import { DatabaseContext } from "../utils/db";
+import { BlockType } from "../utils/mimeTypes";
+import { BlockInsertInfo } from "../utils/dataTypes";
+import { Alert, Keyboard, KeyboardAvoidingView, Platform } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useRouter } from "expo-router";
+
+export default function Capture() {
+  const [textValue, setTextValue] = useState("");
+  const [selectedCollection, setSelectedCollection] = useState<string | null>(
+    null
+  );
+  const [isSaving, setIsSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const { currentUser } = useContext(UserContext);
+  const { createBlocks } = useContext(DatabaseContext);
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+
+  async function handleSave() {
+    const trimmed = textValue.trim();
+    if (!trimmed) return;
+
+    setIsSaving(true);
+    try {
+      const block: BlockInsertInfo = {
+        createdBy: currentUser!.id,
+        content: trimmed,
+        type: BlockType.Text,
+        collectionsToConnect: selectedCollection
+          ? [{ collectionId: selectedCollection }]
+          : [],
+      };
+
+      await createBlocks({
+        blocksToInsert: [block],
+      });
+
+      setTextValue("");
+      setSaved(true);
+      Keyboard.dismiss();
+
+      setTimeout(() => {
+        if (router.canGoBack()) {
+          router.back();
+        } else {
+          router.replace("/(tabs)/home");
+        }
+      }, 600);
+    } catch (err) {
+      Alert.alert("Error", "Failed to save. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  if (!currentUser) {
+    return null;
+  }
+
+  return (
+    <StyledView flex={1} paddingBottom={insets.bottom} paddingTop={insets.top}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        style={{ flex: 1 }}
+      >
+        <YStack paddingHorizontal="$4" gap="$3" flex={1} paddingTop="$2">
+          <XStack justifyContent="space-between" alignItems="center">
+            <H3>Quick Capture</H3>
+            {saved && (
+              <XStack alignItems="center" gap="$1.5">
+                <Icon name="checkmark-circle" color="$green10" size={20} />
+                <StyledText color="$green10">Saved</StyledText>
+              </XStack>
+            )}
+          </XStack>
+
+          <YStack alignItems="flex-start">
+            <CollectionSelect
+              selectedCollection={selectedCollection}
+              setSelectedCollection={setSelectedCollection}
+              collectionPlaceholder="No collection"
+              triggerProps={{
+                theme: "orange",
+                backgroundColor: "$orange6",
+              }}
+              onTriggerSelect={() => {
+                Keyboard.dismiss();
+              }}
+            />
+          </YStack>
+
+          <XStack position="relative" flex={1}>
+            <StyledTextArea
+              value={textValue}
+              onChangeText={setTextValue}
+              placeholder="What do you want to capture?"
+              flex={1}
+              minHeight={150}
+              maxLength={2000}
+              paddingBottom="$8"
+              verticalAlign="top"
+            />
+          </XStack>
+
+          <XStack justifyContent="flex-end" paddingBottom="$2">
+            <StyledButton
+              theme="green"
+              size="$medium"
+              onPress={handleSave}
+              disabled={isSaving || !textValue.trim()}
+              icon={isSaving ? <Spinner size="small" /> : undefined}
+            >
+              {isSaving ? "Saving..." : "Save"}
+            </StyledButton>
+          </XStack>
+        </YStack>
+      </KeyboardAvoidingView>
+    </StyledView>
+  );
+}


### PR DESCRIPTION
This PR was created automatically by Aviator Runbooks.
**Runbook URL**: http://localhost:5000/r/111
**Executed by**: @simsinght

<details>
<summary>💡 Revise with Runbooks</summary>

Use `/aviator revise` to address the feedback provided on this PR:

**As a PR comment:**

- `/aviator revise` - Process all unresolved review comments on the PR
- `/aviator revise [instructions]` - Process any unresolved comments and handle additional instructions.

**As a review comment:**

- Reply with `/aviator revise [instructions]` to an existing review comment to address that specific thread
- Post `/aviator revise [instructions]` as a review comment to have Runbooks revise that code section based on given instructions.

[Read the complete guide with examples](https://docs.aviator.co/runbooks/how-to-guides/providing-feedback)

</details>

## Steps

**Included in this PR**
- 2.1 Create capture screen component

<details>
<summary>View all Runbook steps (3 of 9 complete)</summary>

1. **Add URL Scheme Parameter Handling**
   - 1.1 Add URL parameter parsing utility [#9](https://github.com/aviator-ss-testing/gather/pull/9)
   - 1.2 Add URL scheme listener in root layout [#9](https://github.com/aviator-ss-testing/gather/pull/9)
   - 1.3 Extend DatabaseContext with capture intent state
2. **Create Quick Capture Screen**
   - 2.1 Create capture screen component 👈
   - 2.2 Auto-populate capture screen from URL scheme
   - 2.3 Add quick access to capture screen
3. **Create iOS Shortcut for Text Capture**
   - 3.1 Create basic "Add to Gather" shortcut
   - 3.2 Add shortcut to Home Screen widget
   - 3.3 Optional: Add Siri voice trigger

</details>

<!-- av pr metadata
This comment helps Aviator manage stacked PRs. Please don't delete it.
```
{"parent": "av/rb-111-1-6485", "parentHead": "94d243ad454b179e2d4c5c2017245edfd700d9c0", "parentPull": 9, "trunk": "main"}
```
-->